### PR TITLE
grammar: Close the array properly

### DIFF
--- a/AspectJ.tmLanguage
+++ b/AspectJ.tmLanguage
@@ -1339,7 +1339,7 @@
 					<key>match</key>
 					<string>\b(privileged)\b</string>
 				</dict>
-			</dict>
+			</array>
 		</dict>
 		<key>strings</key>
 		<dict>


### PR DESCRIPTION
Hey @pchaigno!

I'm working on adding better resiliency to the way we do syntax highlighting at GitHub, and I've noticed that this grammar has a small malformed section: an `<array>` block is closed as `</dict>`, something which throws off our new PLIST parser.

Could you merge this patch? :)